### PR TITLE
Added workflow to deploy github pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,64 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build_and_deploy: # deploys app as single page app to the github pages by building app, git checkout gh-pages and pushing the generated files there.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2 # provides access tokens to access repository with git
+      with:
+        fetch-depth: 0 # makes ci fetch complete history for all commits etc
+        
+    - name: Setup git user
+      run: |
+        git config --global user.name "$GITHUB_ACTOR"
+        git config --global user.email "${GITHUB_ACTOR}@bots.github.com"
+        
+    - name: Install dependencies
+      run: npm i --no-progress
+
+    - name: Build app
+      run: npm run build
+
+    - name: Move app content in hierarchy one folder up to be directly in dist
+      run: |
+        cp -r dist/spa/* dist
+        rm -r dist/spa
+    - name: Checkout gh-pages branch
+      run: git checkout gh-pages
+
+    - name: Remove old and unneccessary files
+      run: |
+        shopt -s dotglob # enable hidden files
+        for file in ./*
+        do
+            if [[ "${file##*/}" == "dist" || "${file##*/}" == ".git" || "${file##*/}" == ".gitignore" || "${file##*/}" == ".github" ]]
+            then
+              printf "******* DONT'T delete: ${file##*/}\n"
+            else
+              printf "Delete file or folder: ${file##*/} \n"
+              rm -rf "$file"
+            fi
+        done
+    - name: Move dist folder content to root
+      run: |
+        cp -r -f dist/* ./
+        rm -r dist
+        ls -la
+    - name: Add files to commit
+      run: git add -A
+
+    - name: Commit or not commit that is the question
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          printf "There are changes. \n"
+          git commit -m "updated GitHub Pages"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}"
+          git push --force-with-lease origin gh-pages
+        else
+          printf "No changes, the job is done."
+        fi


### PR DESCRIPTION
This yml file file will build and deploy web app to github pages when a push on main branch is made. DO NOT PULL this until app files are pushed to this repo.

Before you pull make sure:
- [x] publicPath in quasar.conf.js is correct (URL of github pages is: https://mhealth-prototyp.github.io/Basic-Prototyp/)